### PR TITLE
treewide: bring back ToSocketAddrs

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -8,7 +8,7 @@ async fn main() -> Result<()> {
 
     println!("Connecting to {} ...", uri);
 
-    let session = Session::connect(uri.parse()?, None).await?;
+    let session = Session::connect(uri, None).await?;
     session.refresh_topology().await?;
 
     session.query("CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor' : 1}", &[]).await?;

--- a/examples/cqlsh-rs.rs
+++ b/examples/cqlsh-rs.rs
@@ -11,7 +11,7 @@ async fn main() -> Result<()> {
 
     println!("Connecting to {} ...", uri);
 
-    let session = Session::connect(uri.parse()?, Some(Compression::LZ4)).await?;
+    let session = Session::connect(uri, Some(Compression::LZ4)).await?;
 
     let mut rl = Editor::<()>::new();
     loop {

--- a/examples/parallel.rs
+++ b/examples/parallel.rs
@@ -11,7 +11,7 @@ async fn main() -> Result<()> {
 
     println!("Connecting to {} ...", uri);
 
-    let session = Arc::new(Session::connect(uri.parse()?, None).await?);
+    let session = Arc::new(Session::connect(uri, None).await?);
 
     session.query("CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor' : 1}", &[]).await?;
 

--- a/scylla/src/transport/session_test.rs
+++ b/scylla/src/transport/session_test.rs
@@ -5,9 +5,7 @@ use fasthash::murmur3;
 #[tokio::test]
 #[ignore]
 async fn test_unprepared_statement() {
-    let session = Session::connect("127.0.0.1:9042".parse().unwrap(), None)
-        .await
-        .unwrap();
+    let session = Session::connect("localhost:9042", None).await.unwrap();
 
     session.query("CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor' : 1}", &[]).await.unwrap();
     session
@@ -65,9 +63,7 @@ async fn test_unprepared_statement() {
 #[tokio::test]
 #[ignore]
 async fn test_prepared_statement() {
-    let session = Session::connect("127.0.0.1:9042".parse().unwrap(), None)
-        .await
-        .unwrap();
+    let session = Session::connect("localhost:9042", None).await.unwrap();
 
     session.query("CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor' : 1}", &[]).await.unwrap();
     session


### PR DESCRIPTION
The connection now retrieves its associated address from the TCP stream,
and since Scylla only listens on ipv4, the result is guaranteed to be
an ipv4 address.