### PR TITLE
result.rs: streamline parsing of inet data type

### DIFF
--- a/scylla/src/frame/response/result.rs
+++ b/scylla/src/frame/response/result.rs
@@ -296,13 +296,13 @@ fn deser_cql_value(typ: &ColumnType, buf: &mut &[u8]) -> AResult<CQLValue> {
         Text => CQLValue::Text(str::from_utf8(buf)?.to_owned()),
         Inet => CQLValue::Inet(match buf.len() {
             4 => {
-                let raw = types::read_raw_bytes(4, buf)?;
-                let ret = IpAddr::from(<[u8; 4]>::try_from(raw).unwrap());
+                let ret = IpAddr::from(<[u8; 4]>::try_from(&buf[0..4])?);
+                buf.advance(4);
                 ret
             }
             16 => {
-                let raw = types::read_raw_bytes(16, buf)?;
-                let ret = IpAddr::from(<[u8; 16]>::try_from(raw).unwrap());
+                let ret = IpAddr::from(<[u8; 16]>::try_from(&buf[0..16])?);
+                buf.advance(16);
                 ret
             }
             v => {

--- a/scylla/src/frame/types.rs
+++ b/scylla/src/frame/types.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 use std::str;
 use uuid::Uuid;
 
-pub fn read_raw_bytes<'a>(count: usize, buf: &mut &'a [u8]) -> Result<&'a [u8]> {
+fn read_raw_bytes<'a>(count: usize, buf: &mut &'a [u8]) -> Result<&'a [u8]> {
     if buf.len() < count {
         return Err(anyhow!(
             "not enough bytes in buffer: expected {}, was {}",


### PR DESCRIPTION
It's not necessary to use read_raw_bytes because we already check the
length of the buffer before converting to IPv4 or IPv6.