### PR TITLE
examples: parallel execution of prepared statements

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -21,3 +21,7 @@ path = "cqlsh-rs.rs"
 [[example]]
 name = "parallel"
 path = "parallel.rs"
+
+[[example]]
+name = "parallel-prep"
+path = "parallel-prepared.rs"

--- a/examples/parallel-prepared.rs
+++ b/examples/parallel-prepared.rs
@@ -1,0 +1,60 @@
+use anyhow::Result;
+use scylla::transport::session::Session;
+use std::env;
+use std::sync::Arc;
+
+use tokio::sync::Semaphore;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let uri = env::var("SCYLLA_URI").unwrap_or("127.0.0.1:9042".to_string());
+
+    println!("Connecting to {} ...", uri);
+
+    let session = Arc::new(Session::connect(uri, None).await?);
+
+    session.query("CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor' : 1}", &[]).await?;
+
+    session
+        .query(
+            "CREATE TABLE IF NOT EXISTS ks.t2 (a int, b int, c text, primary key (a, b))",
+            &[],
+        )
+        .await?;
+
+    let prepared = Arc::new(
+        session
+            .prepare("INSERT INTO ks.t2 (a, b, c) VALUES (?, ?, 'abc')")
+            .await?,
+    );
+
+    let parallelism = 256;
+    let sem = Arc::new(Semaphore::new(parallelism));
+
+    for i in 0..100_000usize {
+        if i % 1000 == 0 {
+            println!("{}", i);
+        }
+        let session = session.clone();
+        let prepared = prepared.clone();
+        let permit = sem.clone().acquire_owned().await;
+        tokio::task::spawn(async move {
+            let i = i;
+            session
+                .execute(&prepared, &scylla::values!(i as i32, 2 * i as i32))
+                .await
+                .unwrap();
+
+            let _permit = permit;
+        });
+    }
+
+    // Wait for all in-flight requests to finish
+    for _ in 0..parallelism {
+        sem.acquire().await.forget();
+    }
+
+    println!("Ok.");
+
+    Ok(())
+}


### PR DESCRIPTION
Interestingly, this one is much slower than the standard `parallel` example.
May be because we need to query the Ring.