### PR TITLE
Fix (or break?) murmur hash implementation

### DIFF
--- a/examples/compare-tokens.rs
+++ b/examples/compare-tokens.rs
@@ -23,7 +23,7 @@ async fn main() -> Result<()> {
 
     let prepared = session.prepare("INSERT INTO ks.t (pk) VALUES (?)").await?;
 
-    for pk in 0..100_i64 {
+    for pk in (0..100_i64).chain(99840..99936_i64) {
         session
             .query("INSERT INTO ks.t (pk) VALUES (?)", &scylla::values!(pk))
             .await?;

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -16,7 +16,6 @@ futures = "0.3.6"
 num_enum = "0.5"
 compress = "0.2.1"
 tokio = { version = "0.3.0", features = ["net", "time", "io-util", "sync", "rt", "macros"] }
-fasthash = "0.4.0"
 snappy = "0.4.0"
 uuid = "0.8.1"
 


### PR DESCRIPTION
In order to be compatible with Cassandra, we can't use an implementation
from a library. The original implementation of murmur hash in Cassandra
was bugged, and we need to replicate those bugs.

Extends the compare-token example with pks that gave incorrect tokens in
the previous implementation.